### PR TITLE
Add basic mini app UI with navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # BilimMiniApp
 
-This repository contains a minimal Telegram Mini App frontend built with Vue and Vite.
+A small Telegram Mini App built with Vue 3 and Vite. It demonstrates theme switching, a bottom navigation bar and several screens including registration, tests, achievements and profile.
+
+Run the frontend locally:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
     <title>Telegram Mini App</title>
   </head>
   <body>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@telegram-apps/sdk-vue": "^2.0.25",
-        "vue": "^3.5.13"
+        "vue": "^3.5.13",
+        "vue-router": "^4.5.1"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.2.3",
@@ -939,6 +940,12 @@
         "@vue/shared": "3.5.16"
       }
     },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
     "node_modules/@vue/reactivity": {
       "version": "3.5.16",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.16.tgz",
@@ -1367,6 +1374,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "@telegram-apps/sdk-vue": "^2.0.25",
-    "vue": "^3.5.13"
+    "vue": "^3.5.13",
+    "vue-router": "^4.5.1"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,15 +1,37 @@
 <template>
-  <div class="app">
-    <h1>Telegram Mini App</h1>
+  <div :data-theme="theme" class="app">
+    <router-view />
+    <BottomNav />
+    <button class="theme-toggle" @click="toggleTheme">{{ themeLabel }}</button>
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref, computed } from 'vue'
+import BottomNav from './components/BottomNav.vue'
+
+const theme = ref(localStorage.getItem('theme') || 'light')
+const themeLabel = computed(() => (theme.value === 'dark' ? 'Светлая тема' : 'Тёмная тема'))
+
+function toggleTheme() {
+  theme.value = theme.value === 'dark' ? 'light' : 'dark'
+  localStorage.setItem('theme', theme.value)
+}
 </script>
 
 <style scoped>
 .app {
-  text-align: center;
-  margin-top: 2rem;
+  position: relative;
+  min-height: 100vh;
+  padding-bottom: 3.5rem;
+}
+.theme-toggle {
+  position: fixed;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: var(--card-bg);
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
 }
 </style>

--- a/frontend/src/components/BottomNav.vue
+++ b/frontend/src/components/BottomNav.vue
@@ -1,0 +1,53 @@
+<template>
+  <nav class="bottom-nav">
+    <router-link to="/tests" class="item" :class="{ active: isActive('/tests') }">
+      <span class="icon">🏁</span>
+      <span class="label">Тесты</span>
+    </router-link>
+    <router-link to="/achievements" class="item" :class="{ active: isActive('/achievements') }">
+      <span class="icon">🏆</span>
+      <span class="label">Достижения</span>
+    </router-link>
+    <router-link to="/profile" class="item" :class="{ active: isActive('/profile') }">
+      <span class="icon">👤</span>
+      <span class="label">Профиль</span>
+    </router-link>
+  </nav>
+</template>
+
+<script setup lang="ts">
+import { useRoute } from 'vue-router'
+const route = useRoute()
+function isActive(path: string) {
+  return route.path.startsWith(path)
+}
+</script>
+
+<style scoped>
+.bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  background: var(--nav-bg);
+  border-top: 1px solid var(--border-color);
+}
+.item {
+  flex: 1;
+  text-align: center;
+  padding: 0.5rem 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 0.9rem;
+  color: var(--text-color);
+  text-decoration: none;
+}
+.item.active {
+  color: var(--accent-color);
+}
+.icon {
+  font-size: 1.2rem;
+}
+</style>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,8 +3,9 @@ import App from './App.vue'
 import './style.css'
 import { setupTelegram } from './telegram'
 import { authorize } from './api'
+import { router } from './router'
 
 setupTelegram()
 authorize().catch(console.error)
 
-createApp(App).mount('#app')
+createApp(App).use(router).mount('#app')

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -1,0 +1,31 @@
+import { createRouter, createWebHashHistory, RouteRecordRaw } from 'vue-router'
+import RegisterView from './views/RegisterView.vue'
+import TestsView from './views/TestsView.vue'
+import AchievementsView from './views/AchievementsView.vue'
+import ProfileView from './views/ProfileView.vue'
+import TestView from './views/TestView.vue'
+import ResultsView from './views/ResultsView.vue'
+
+const routes: Array<RouteRecordRaw> = [
+  { path: '/', redirect: '/tests' },
+  { path: '/register', component: RegisterView },
+  { path: '/tests', component: TestsView },
+  { path: '/achievements', component: AchievementsView },
+  { path: '/profile', component: ProfileView },
+  { path: '/test/:id', component: TestView },
+  { path: '/results/:id', component: ResultsView }
+]
+
+export const router = createRouter({
+  history: createWebHashHistory(),
+  routes
+})
+
+router.beforeEach((to, _from, next) => {
+  const registered = !!localStorage.getItem('userName')
+  if (!registered && to.path !== '/register') {
+    next('/register')
+  } else {
+    next()
+  }
+})

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,79 +1,29 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  --font-family: 'Inter', system-ui, sans-serif;
+  --accent-color: #0d6efd;
+  --text-color: #212529;
+  --background-color: #ffffff;
+  --card-bg: #f1f3f5;
+  --nav-bg: #ffffff;
+  --border-color: #dee2e6;
 }
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+[data-theme='dark'] {
+  --text-color: #f8f9fa;
+  --background-color: #212529;
+  --card-bg: #343a40;
+  --nav-bg: #212529;
+  --border-color: #495057;
 }
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
+  font-family: var(--font-family);
+  color: var(--text-color);
+  background: var(--background-color);
   min-height: 100vh;
 }
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+.page {
+  padding-bottom: 3.5rem; /* space for nav */
 }
-
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-.card {
-  padding: 2em;
-}
-
-#app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  font-family: var(--font-family);
 }

--- a/frontend/src/views/AchievementsView.vue
+++ b/frontend/src/views/AchievementsView.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="page">
+    <h1>Достижения</h1>
+    <p>Здесь будут ваши достижения.</p>
+  </div>
+</template>
+
+<script setup lang="ts"></script>
+
+<style scoped>
+.page {
+  padding: 1rem;
+}
+</style>

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="page">
+    <h1>Профиль</h1>
+    <p>Имя: {{ name }}</p>
+    <p>Язык: {{ language }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+const name = ref('')
+const language = ref('')
+
+onMounted(() => {
+  name.value = localStorage.getItem('userName') || ''
+  language.value = localStorage.getItem('language') || ''
+})
+</script>
+
+<style scoped>
+.page {
+  padding: 1rem;
+}
+</style>

--- a/frontend/src/views/RegisterView.vue
+++ b/frontend/src/views/RegisterView.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="register">
+    <h2>Выберите язык</h2>
+    <select v-model="language">
+      <option value="ru">Русский</option>
+      <option value="ky">Кыргызский</option>
+      <option value="en">English</option>
+    </select>
+    <h2>Введите имя</h2>
+    <input v-model="name" type="text" placeholder="Имя" />
+    <button @click="proceed">Продолжить</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+const name = ref('')
+const language = ref('ru')
+
+function proceed() {
+  if (!name.value) return
+  localStorage.setItem('userName', name.value)
+  localStorage.setItem('language', language.value)
+  router.push('/tests')
+}
+</script>
+
+<style scoped>
+.register {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+select,
+input,
+button {
+  font-size: 1rem;
+  padding: 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+}
+button {
+  background: var(--accent-color);
+  color: #fff;
+}
+</style>

--- a/frontend/src/views/ResultsView.vue
+++ b/frontend/src/views/ResultsView.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="page">
+    <h1>Результаты</h1>
+    <p>Ваш результат: {{ score }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+import { apiFetch } from '../api'
+
+const score = ref(0)
+const route = useRoute()
+
+onMounted(async () => {
+  try {
+    const res = await apiFetch(`/api/tests/${route.params.id}/result`)
+    if (res.ok) {
+      const data = await res.json()
+      score.value = data.score
+    }
+  } catch (e) {
+    console.error(e)
+  }
+})
+</script>
+
+<style scoped>
+.page {
+  padding: 1rem;
+}
+</style>

--- a/frontend/src/views/TestView.vue
+++ b/frontend/src/views/TestView.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="page" v-if="question">
+    <h2>{{ question.text }}</h2>
+    <img v-if="question.image" :src="question.image" class="q-image" />
+    <div class="options">
+      <button v-for="(opt, idx) in question.options" :key="idx" @click="select(idx)">
+        {{ opt }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { apiFetch } from '../api'
+
+interface Question {
+  text: string
+  image?: string
+  options: string[]
+}
+
+const route = useRoute()
+const router = useRouter()
+const question = ref<Question | null>(null)
+
+onMounted(async () => {
+  try {
+    const res = await apiFetch(`/api/tests/${route.params.id}/question`)
+    if (res.ok) {
+      question.value = await res.json()
+    }
+  } catch (e) {
+    console.error(e)
+  }
+})
+
+function select(idx: number) {
+  router.push(`/results/${route.params.id}`)
+}
+</script>
+
+<style scoped>
+.page {
+  padding: 1rem;
+}
+.q-image {
+  max-width: 100%;
+  border-radius: 8px;
+  margin: 0.5rem 0;
+}
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+button {
+  padding: 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+  background: var(--card-bg);
+}
+</style>

--- a/frontend/src/views/TestsView.vue
+++ b/frontend/src/views/TestsView.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="page">
+    <h1>Тесты</h1>
+    <div class="tests">
+      <div v-for="subject in subjects" :key="subject.id" class="card" @click="open(subject.id)">
+        <span class="icon">📚</span>
+        <span>{{ subject.name }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { apiFetch } from '../api'
+
+const router = useRouter()
+const subjects = ref<Array<{ id: number; name: string }>>([])
+
+onMounted(async () => {
+  try {
+    const res = await apiFetch('/api/subjects')
+    if (res.ok) {
+      const data = await res.json()
+      subjects.value = data
+    }
+  } catch (e) {
+    console.error(e)
+  }
+})
+
+function open(id: number) {
+  router.push(`/test/${id}`)
+}
+</script>
+
+<style scoped>
+.page {
+  padding: 1rem;
+}
+.tests {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.card {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  border-radius: 12px;
+  background: var(--card-bg);
+  cursor: pointer;
+}
+.icon {
+  font-size: 1.5rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- implement registration, tests, achievements and profile pages
- add Vue Router and bottom navigation component
- enable theme switching and load Inter font
- update README with instructions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684be06fe4888325922bb4706f0b9dd1