### PR TITLE
Handle non-Telegram environment

### DIFF
--- a/src/components/OpenTelegram.vue
+++ b/src/components/OpenTelegram.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="open-telegram">
+    <h1>Откройте приложение в Telegram</h1>
+    <p>
+      Для использования мини‑приложения перейдите по ссылке ниже или
+      отсканируйте QR‑код.
+    </p>
+    <a :href="telegramLink" target="_blank" class="tg-link">Открыть в Telegram</a>
+    <img :src="qrUrl" alt="QR code" class="qr" />
+  </div>
+</template>
+
+<script setup lang="ts">
+const telegramLink = 'https://t.me/your_channel';
+const qrUrl = `https://api.qrserver.com/v1/create-qr-code/?size=150x150&data=${encodeURIComponent(telegramLink)}`;
+</script>
+
+<style scoped>
+.open-telegram {
+  text-align: center;
+  padding: 2rem;
+}
+.qr {
+  margin-top: 1rem;
+  width: 150px;
+  height: 150px;
+}
+.tg-link {
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: var(--accent-color);
+  color: #fff;
+  border-radius: 8px;
+  text-decoration: none;
+}
+</style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,8 +4,14 @@ import './style.css'
 import { setupTelegram } from './telegram'
 import { authorize } from './api'
 import { router } from './router'
+import OpenTelegram from './components/OpenTelegram.vue'
 
-setupTelegram()
-authorize().catch(console.error)
+const isTelegram = typeof window !== 'undefined' && !!(window as any).Telegram?.WebApp
 
-createApp(App).use(router).mount('#app')
+if (isTelegram) {
+  setupTelegram()
+  authorize().catch(console.error)
+  createApp(App).use(router).mount('#app')
+} else {
+  createApp(OpenTelegram).mount('#app')
+}


### PR DESCRIPTION
## Summary
- add component with link and QR to Telegram
- detect Telegram context in `main.ts`
- if not in Telegram show QR/link page

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c2adf2d6c8325b3af2aeb4b1451c6