### PR TITLE
Implement backend registration flow

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,8 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import './style.css'
-import { setupTelegram } from './telegram'
-import { authorize } from './api'
+import { setupTelegram, getTelegramUser } from './telegram'
+import { authorize, userExists } from './api'
 import { router } from './router'
 import OpenTelegram from './components/OpenTelegram.vue'
 
@@ -13,7 +13,21 @@ const isTelegram =
 
 if (isTelegram) {
   setupTelegram()
-  authorize().catch(console.error)
+  authorize()
+    .then(async () => {
+      const user = getTelegramUser()
+      if (user) {
+        try {
+          const exists = await userExists(user.id)
+          if (exists) {
+            localStorage.setItem('registered', '1')
+          }
+        } catch (e) {
+          console.error(e)
+        }
+      }
+    })
+    .catch(console.error)
   router.push('/tests').then(r => r)
   createApp(App).use(router).mount('#app')
 } else {

--- a/src/router.ts
+++ b/src/router.ts
@@ -22,7 +22,7 @@ export const router = createRouter({
 })
 
 router.beforeEach((to, _from, next) => {
-  const registered = !!localStorage.getItem('userName')
+  const registered = localStorage.getItem('registered') === '1'
   if (!registered && to.path !== '/register') {
     next('/register')
   } else {

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -7,3 +7,15 @@ export function setupTelegram(): void {
 export function getInitData(): string {
   return window?.Telegram?.WebApp?.initData || ''
 }
+
+export interface TelegramUser {
+  id: number
+  first_name?: string
+  last_name?: string
+  username?: string
+  language_code?: string
+}
+
+export function getTelegramUser(): TelegramUser | null {
+  return (window as any)?.Telegram?.WebApp?.initDataUnsafe?.user || null
+}

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -8,12 +8,25 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { apiFetch } from '../api'
+import { getTelegramUser } from '../telegram'
+
 const name = ref('')
 const language = ref('')
 
-onMounted(() => {
-  name.value = localStorage.getItem('userName') || ''
-  language.value = localStorage.getItem('language') || ''
+onMounted(async () => {
+  const user = getTelegramUser()
+  if (!user) return
+  try {
+    const res = await apiFetch(`/api/mobile/users/${user.id}`)
+    if (res.ok) {
+      const data = await res.json()
+      name.value = `${data.firstName} ${data.lastName}`
+      language.value = data.language
+    }
+  } catch (e) {
+    console.error(e)
+  }
 })
 </script>
 

--- a/src/views/RegisterView.vue
+++ b/src/views/RegisterView.vue
@@ -2,29 +2,90 @@
   <div class="register">
     <h2>Выберите язык</h2>
     <select v-model="language">
-      <option value="ru">Русский</option>
-      <option value="ky">Кыргызский</option>
-      <option value="en">English</option>
+      <option value="RU">Русский</option>
+      <option value="KY">Кыргызский</option>
+      <option value="EN">English</option>
     </select>
-    <h2>Введите имя</h2>
-    <input v-model="name" type="text" placeholder="Имя" />
-    <button @click="proceed">Продолжить</button>
+
+    <h2>Область</h2>
+    <select v-model.number="regionId">
+      <option disabled value="">Выберите область</option>
+      <option v-for="r in regions" :key="r.id" :value="r.id">{{ r.name }}</option>
+    </select>
+
+    <h2>Город</h2>
+    <select v-model.number="cityId" :disabled="!regionId">
+      <option disabled value="">Выберите город</option>
+      <option v-for="c in cities" :key="c.id" :value="c.id">{{ c.name }}</option>
+    </select>
+
+    <h2>Школа</h2>
+    <select v-model.number="schoolId" :disabled="!cityId">
+      <option disabled value="">Выберите школу</option>
+      <option v-for="s in schools" :key="s.id" :value="s.id">{{ s.name }}</option>
+    </select>
+
+    <button @click="proceed" :disabled="!schoolId">Продолжить</button>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
+import { fetchRegions, fetchCities, fetchSchools, registerUser } from '../api'
 
 const router = useRouter()
-const name = ref('')
-const language = ref('ru')
+const language = ref('RU')
 
-function proceed() {
-  if (!name.value) return
-  localStorage.setItem('userName', name.value)
-  localStorage.setItem('language', language.value)
-  router.push('/tests')
+const regions = ref<Array<{ id: number; name: string }>>([])
+const cities = ref<Array<{ id: number; name: string }>>([])
+const schools = ref<Array<{ id: number; name: string }>>([])
+const regionId = ref<number | null>(null)
+const cityId = ref<number | null>(null)
+const schoolId = ref<number | null>(null)
+
+onMounted(async () => {
+  try {
+    regions.value = await fetchRegions()
+  } catch (e) {
+    console.error(e)
+  }
+})
+
+watch(regionId, async id => {
+  if (!id) return
+  cityId.value = null
+  schoolId.value = null
+  cities.value = []
+  schools.value = []
+  try {
+    cities.value = await fetchCities(id)
+  } catch (e) {
+    console.error(e)
+  }
+})
+
+watch(cityId, async id => {
+  if (!id) return
+  schoolId.value = null
+  schools.value = []
+  try {
+    schools.value = await fetchSchools(id)
+  } catch (e) {
+    console.error(e)
+  }
+})
+
+async function proceed() {
+  if (!schoolId.value) return
+  try {
+    await registerUser({ schoolId: schoolId.value, language: language.value })
+    localStorage.setItem('language', language.value)
+    localStorage.setItem('registered', '1')
+    router.push('/tests')
+  } catch (e) {
+    console.error(e)
+  }
 }
 </script>
 

--- a/src/views/TestsView.vue
+++ b/src/views/TestsView.vue
@@ -20,7 +20,7 @@ const subjects = ref<Array<{ id: number; name: string }>>([])
 
 onMounted(async () => {
   try {
-    const res = await apiFetch('/api/subjects')
+    const res = await apiFetch('/api/mobile/subjects')
     if (res.ok) {
       const data = await res.json()
       subjects.value = data


### PR DESCRIPTION
## Summary
- connect to backend API
- use new `/api/mobile/subjects` path
- add Telegram user helpers and registration requests
- support region/city/school selection and registration
- check registration state when app starts
- fetch profile data from backend

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684cfddebe3c8325917f1e12b84d3d28