### PR TITLE
Integrate Telegram WebApp features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@telegram-apps/sdk-vue": "^2.0.25",
         "vue": "^3.5.13",
         "vue-router": "^4.5.1"
       },
@@ -775,100 +774,6 @@
         "win32"
       ]
     },
-    "node_modules/@telegram-apps/bridge": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/bridge/-/bridge-2.8.3.tgz",
-      "integrity": "sha512-3PpWDa+NZ5Zk5jvsNrJhF7D1wOjMraYW9aIJhGC1Tz3EHiHIcw6QZXWd/pHm3b3DzfpdlP60L44+63ackU8s7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@telegram-apps/signals": "^1.1.2",
-        "@telegram-apps/toolkit": "^2.1.3",
-        "@telegram-apps/transformers": "^2.2.4",
-        "@telegram-apps/types": "^2.0.1",
-        "better-promises": "^0.4.1",
-        "error-kid": "^0.0.7",
-        "mitt": "^3.0.1",
-        "valibot": "1.0.0"
-      }
-    },
-    "node_modules/@telegram-apps/navigation": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/navigation/-/navigation-1.0.14.tgz",
-      "integrity": "sha512-bqNgF/J8Po7ZtsELm3E1a6aPr7awwxO3sIqD8J6u12urOlGoW5+1KxKKbkPa58mgXuQdsltd8apI+OVy0IYiUA==",
-      "license": "MIT"
-    },
-    "node_modules/@telegram-apps/sdk": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/sdk/-/sdk-3.10.1.tgz",
-      "integrity": "sha512-MiJZN/YdAEjdBy/BXcIBA89whebG/DOSAAXjDliviBKVI4NXhqU/viM7QC1Gj+ZJNirsL/HWYNo2R8dMxfsVrw==",
-      "license": "MIT",
-      "dependencies": {
-        "@telegram-apps/bridge": "^2.8.3",
-        "@telegram-apps/navigation": "^1.0.14",
-        "@telegram-apps/signals": "^1.1.2",
-        "@telegram-apps/toolkit": "^2.1.3",
-        "@telegram-apps/transformers": "^2.2.4",
-        "@telegram-apps/types": "^2.0.1",
-        "better-promises": "^0.4.1",
-        "error-kid": "^0.0.7",
-        "valibot": "1.0.0"
-      }
-    },
-    "node_modules/@telegram-apps/sdk-vue": {
-      "version": "2.0.25",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/sdk-vue/-/sdk-vue-2.0.25.tgz",
-      "integrity": "sha512-ywhl54H+VnDWpRlL+DkxwSYqid5m5lh2a+iriku++dDFISZNQK3LJISnV2nxbuK5LUB2oR3o77eibSI0yVJ/cw==",
-      "license": "MIT",
-      "dependencies": {
-        "@telegram-apps/sdk": "^3.10.1"
-      },
-      "peerDependencies": {
-        "vue": "^3.0.0"
-      }
-    },
-    "node_modules/@telegram-apps/signals": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/signals/-/signals-1.1.2.tgz",
-      "integrity": "sha512-1P1kdCLX7MfETGPxH7f3UZKIsdE7Tz5S7QmN4Km1sbYQMakD5Bi1NecSMR7/wnHp50gWMI1JzENcMtCEmouhSg==",
-      "license": "MIT"
-    },
-    "node_modules/@telegram-apps/toolkit": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/toolkit/-/toolkit-2.1.3.tgz",
-      "integrity": "sha512-LPUBL7hxQTOr+Dowyk9a1O82nQS4ja4+OYiYWtvqq5nNUHC6Gbbus0zGWCbFcj9CLnIzaeb5HWOg5iSnhoRcyg==",
-      "license": "MIT"
-    },
-    "node_modules/@telegram-apps/transformers": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/transformers/-/transformers-2.2.4.tgz",
-      "integrity": "sha512-PZemIzOIdz6VwS9vMbwr+Fco+jyjRVAUrkDex1ZS3As4eegJInl6vj43YaO0n8UEWdANzUF8ho4lQtkLHvwwiA==",
-      "license": "MIT",
-      "dependencies": {
-        "@telegram-apps/toolkit": "^2.1.3",
-        "@telegram-apps/types": "^2.0.1",
-        "valibot": "1.0.0-beta.14"
-      }
-    },
-    "node_modules/@telegram-apps/transformers/node_modules/valibot": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.0.0-beta.14.tgz",
-      "integrity": "sha512-tLyV2rE5QL6U29MFy3xt4AqMrn+/HErcp2ZThASnQvPMwfSozjV1uBGKIGiegtZIGjinJqn0SlBdannf18wENA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@telegram-apps/types": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@telegram-apps/types/-/types-2.0.1.tgz",
-      "integrity": "sha512-l9BSXPEhtZG6q6MCa30p5/x0XWwG4ymEOrLD8YN9TEAil6qjYwDJea9R3gUjxsadsJW7XtaZkg2UD6k7owfqjw==",
-      "license": "MIT"
-    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -996,15 +901,6 @@
       "integrity": "sha512-c/0fWy3Jw6Z8L9FmTyYfkpM5zklnqqa9+a6dz3DvONRKW2NEbh46BP0FHuLFSWi2TnQEtp91Z6zOWNrU6QiyPg==",
       "license": "MIT"
     },
-    "node_modules/better-promises": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/better-promises/-/better-promises-0.4.1.tgz",
-      "integrity": "sha512-cDW7eMvhvCoWzSih5o/OxsAgTUfP05yGMq77xNZUTmcZoNU9vEeFZJ+yJJi4lnocvxFrVFKsG0Yxt7ZnuYJEig==",
-      "license": "MIT",
-      "dependencies": {
-        "error-kid": "^0.0.7"
-      }
-    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -1022,12 +918,6 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
-    },
-    "node_modules/error-kid": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/error-kid/-/error-kid-0.0.7.tgz",
-      "integrity": "sha512-8mFs7ZaDWlBFgjOy4lHLMCe2+KZfZXGx5GOgh2VQ/M1CCIvSWzbl2OMl+5fdZgrgoUfhTeF+NPhmqfEvUhN8yw==",
-      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.5",
@@ -1114,12 +1004,6 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
-    },
-    "node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -1264,20 +1148,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/valibot": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.0.0.tgz",
-      "integrity": "sha512-1Hc0ihzWxBar6NGeZv7fPLY0QuxFMyxwYR2sF1Blu7Wq7EnremwY2W02tit2ij2VJT8HcSkHAQqmFfl77f73Yw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "typescript": ">=5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@telegram-apps/sdk-vue": "^2.0.25",
     "vue": "^3.5.13",
     "vue-router": "^4.5.1"
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,12 +3,14 @@
     <router-view />
     <BottomNav />
     <button class="theme-toggle" @click="toggleTheme">{{ themeLabel }}</button>
+    <button class="close-btn" @click="closeApp">✖</button>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import BottomNav from './components/BottomNav.vue'
+import { close } from './telegram'
 
 const theme = ref(localStorage.getItem('theme') || 'light')
 const themeLabel = computed(() => (theme.value === 'dark' ? 'Светлая тема' : 'Тёмная тема'))
@@ -16,6 +18,10 @@ const themeLabel = computed(() => (theme.value === 'dark' ? 'Светлая те
 function toggleTheme() {
   theme.value = theme.value === 'dark' ? 'light' : 'dark'
   localStorage.setItem('theme', theme.value)
+}
+
+function closeApp() {
+  close()
 }
 
 watch(
@@ -37,6 +43,16 @@ watch(
   position: fixed;
   top: 0.5rem;
   right: 0.5rem;
+  background: var(--card-bg);
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  color: var(--text-color);
+}
+.close-btn {
+  position: fixed;
+  top: 0.5rem;
+  left: 0.5rem;
   background: var(--card-bg);
   border: none;
   padding: 0.5rem 1rem;

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -1,7 +1,8 @@
-import { init } from '@telegram-apps/sdk-vue'
-
 export function setupTelegram(): void {
-  init()
+  const tg = (window as any)?.Telegram?.WebApp
+  if (!tg) return
+  tg.ready()
+  tg.expand()
 }
 
 export function getInitData(): string {
@@ -18,4 +19,21 @@ export interface TelegramUser {
 
 export function getTelegramUser(): TelegramUser | null {
   return (window as any)?.Telegram?.WebApp?.initDataUnsafe?.user || null
+}
+
+export function close(): void {
+  (window as any)?.Telegram?.WebApp?.close()
+}
+
+export function sendData(data: unknown): void {
+  const str = typeof data === 'string' ? data : JSON.stringify(data)
+  ;(window as any)?.Telegram?.WebApp?.sendData(str)
+}
+
+export function openLink(url: string, tryInWebView = false): void {
+  ;(window as any)?.Telegram?.WebApp?.openLink(url, tryInWebView)
+}
+
+export function openTelegramLink(url: string): void {
+  ;(window as any)?.Telegram?.WebApp?.openTelegramLink(url)
 }

--- a/src/views/RegisterView.vue
+++ b/src/views/RegisterView.vue
@@ -33,6 +33,7 @@
 import { ref, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { fetchRegions, fetchCities, fetchSchools, registerUser } from '../api'
+import { sendData } from '../telegram'
 
 const router = useRouter()
 const language = ref('RU')
@@ -87,6 +88,7 @@ async function proceed() {
     console.log('proceed: registration complete')
     localStorage.setItem('language', language.value)
     localStorage.setItem('registered', '1')
+    sendData('registered')
     router.push('/tests')
   } catch (e) {
     console.error(e)

--- a/src/views/ResultsView.vue
+++ b/src/views/ResultsView.vue
@@ -2,6 +2,7 @@
   <div class="page">
     <h1>Результаты</h1>
     <p>Ваш результат: {{ score }}</p>
+    <button @click="share">Отправить результат</button>
   </div>
 </template>
 
@@ -9,6 +10,7 @@
 import { ref, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { apiFetch } from '../api'
+import { sendData } from '../telegram'
 
 const score = ref(0)
 const route = useRoute()
@@ -24,6 +26,10 @@ onMounted(async () => {
     console.error(e)
   }
 })
+
+function share() {
+  sendData(`score:${score.value}`)
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- integrate Telegram WebApp directly and expose helper functions
- add close button and wire up to Telegram close
- send registration and result data via `sendData`
- remove unused telegram sdk dependency

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684da78e9590832595f38981b64e788a