### PR TITLE
Fix auth mount timing

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,9 +31,17 @@ if (isTelegram) {
         }
       }
     })
-    .catch(console.error)
-  router.push('/tests').then(r => r)
-  createApp(App).use(router).mount('#app')
+    .then(() => {
+      router.push('/tests').then(r => r)
+      createApp(App).use(router).mount('#app')
+    })
+    .catch(e => {
+      console.error(e)
+      const root = document.getElementById('app')
+      if (root) {
+        root.innerHTML = 'Authentication failed'
+      }
+    })
 } else {
   createApp(OpenTelegram).mount('#app')
 }


### PR DESCRIPTION
## Summary
- wait for authorization before mounting the Telegram mini app
- show a message when authentication fails

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684dc413898c8325be37a77429bb0cc1