### PR TITLE
Improve navigation bar style

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -36,7 +36,7 @@ watch(
 .app {
   position: relative;
   min-height: 100vh;
-  padding-bottom: 3.5rem;
+  padding-bottom: calc(4.5rem + env(safe-area-inset-bottom));
 }
 .theme-toggle {
   position: fixed;

--- a/src/components/BottomNav.vue
+++ b/src/components/BottomNav.vue
@@ -45,28 +45,45 @@ function navigate(path: string) {
 <style scoped>
 .bottom-nav {
   position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  bottom: calc(env(safe-area-inset-bottom) + 0.5rem);
+  left: 50%;
+  transform: translateX(-50%);
   display: flex;
-  background: var(--nav-bg);
-  border-top: 1px solid var(--border-color);
+  justify-content: space-around;
+  width: calc(100% - 2rem);
+  max-width: 500px;
+  padding: 0.5rem 0.25rem calc(0.5rem + env(safe-area-inset-bottom)) 0.25rem;
+  background: var(--nav-bg-translucent);
+  backdrop-filter: blur(16px);
+  border-radius: 16px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 }
 .item {
   flex: 1;
   text-align: center;
-  padding: 0.5rem 0;
+  position: relative;
+  padding: 0.25rem 0;
   display: flex;
   flex-direction: column;
   align-items: center;
-  font-size: 0.9rem;
+  font-size: 0.8rem;
   color: var(--text-color);
   cursor: pointer;
 }
 .item.active {
   color: var(--accent-color);
 }
+.item.active::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 25%;
+  right: 25%;
+  height: 3px;
+  border-radius: 2px 2px 0 0;
+  background: var(--accent-color);
+}
 .icon {
-  font-size: 1.2rem;
+  font-size: 1.4rem;
 }
 </style>

--- a/src/style.css
+++ b/src/style.css
@@ -5,6 +5,7 @@
   --background-color: #ffffff;
   --card-bg: #f1f3f5;
   --nav-bg: #ffffff;
+  --nav-bg-translucent: rgba(255, 255, 255, 0.8);
   --border-color: #dee2e6;
 }
 [data-theme='dark'] {
@@ -12,6 +13,7 @@
   --background-color: #121212;
   --card-bg: #1e1e1e;
   --nav-bg: #121212;
+  --nav-bg-translucent: rgba(18, 18, 18, 0.9);
   --border-color: #343a40;
 }
 body {
@@ -22,7 +24,7 @@ body {
   min-height: 100vh;
 }
 .page {
-  padding-bottom: 3.5rem; /* space for nav */
+  padding-bottom: calc(4.5rem + env(safe-area-inset-bottom));
 }
 button {
   font-family: var(--font-family);


### PR DESCRIPTION
## Summary
- update CSS variables for translucent navigation bar
- add safe-area support and new styling for bottom navigation
- adjust default page padding for the new nav bar
- tweak app container padding

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684dca201e6883258cbb26ec61cd0873