### PR TITLE
Implement theme icon toggle and disable text selection

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,13 @@
   <div class="app">
     <router-view />
     <BottomNav />
-    <button class="theme-toggle" @click="toggleTheme">{{ themeLabel }}</button>
+    <button
+      class="theme-toggle"
+      @click="toggleTheme"
+      :aria-label="themeLabel"
+    >
+      {{ themeIcon }}
+    </button>
   </div>
 </template>
 
@@ -12,7 +18,10 @@ import BottomNav from './components/BottomNav.vue'
 import { close } from './telegram'
 
 const theme = ref(localStorage.getItem('theme') || 'light')
-const themeLabel = computed(() => (theme.value === 'dark' ? 'Светлая тема' : 'Тёмная тема'))
+const themeLabel = computed(() =>
+  theme.value === 'dark' ? 'Светлая тема' : 'Тёмная тема'
+)
+const themeIcon = computed(() => (theme.value === 'dark' ? '🌞' : '🌙'))
 
 function toggleTheme() {
   theme.value = theme.value === 'dark' ? 'light' : 'dark'

--- a/src/style.css
+++ b/src/style.css
@@ -22,6 +22,9 @@ body {
   color: var(--text-color);
   background: var(--background-color);
   min-height: 100vh;
+  user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
 }
 .page {
   padding-bottom: calc(4.5rem + env(safe-area-inset-bottom));


### PR DESCRIPTION
## Summary
- disable text selection globally
- switch theme using a sun/moon icon instead of text
- include the aria label for better a11y

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dcceec47c8325b5bce8a2479fbfb8