### PR TITLE
Fix Telegram header color

### DIFF
--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -5,7 +5,7 @@ export function setupTelegram(): void {
   tg.expand()
   // Use dark header and hide the default main button for a clean look
   try {
-    tg.setHeaderColor('dark')
+    tg.setHeaderColor('#000000')
     tg.MainButton.hide()
   } catch (e) {
     console.error('Telegram WebApp API error', e)


### PR DESCRIPTION
## Summary
- use valid hex color for Telegram header

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dd01751bc83259ad894869847b4d0