### PR TITLE
Refine layout and replace placeholder content

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -51,7 +51,7 @@ watch(
   height: 100%;
   box-sizing: border-box;
   padding-bottom: calc(
-    4.5rem + var(--tg-content-safe-area-inset-bottom, var(--tg-safe-area-inset-bottom, env(safe-area-inset-bottom)))
+    5rem + var(--tg-content-safe-area-inset-bottom, var(--tg-safe-area-inset-bottom, env(safe-area-inset-bottom)))
   );
   padding-top: var(
     --tg-content-safe-area-inset-top,

--- a/src/components/BottomNav.vue
+++ b/src/components/BottomNav.vue
@@ -47,7 +47,7 @@ function navigate(path: string) {
   position: fixed;
   bottom: calc(
     var(--tg-content-safe-area-inset-bottom, var(--tg-safe-area-inset-bottom, env(safe-area-inset-bottom))) +
-      0.5rem
+      1rem
   );
   left: 50%;
   transform: translateX(-50%);

--- a/src/style.css
+++ b/src/style.css
@@ -67,3 +67,10 @@ button {
   background: var(--accent-color);
   color: #fff;
 }
+
+.card {
+  background: var(--card-bg);
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}

--- a/src/views/AchievementsView.vue
+++ b/src/views/AchievementsView.vue
@@ -1,23 +1,68 @@
 <template>
   <div class="page">
-    <img
-      src="https://media.giphy.com/media/3o6UBpHgaXFDNAuttm/giphy.gif"
-      alt="sticker"
-      class="sticker"
-    />
-    <p>Здесь будут ваши достижения.</p>
+    <h2>Достижения</h2>
+    <div class="achievements">
+      <div class="card" v-for="a in achievements" :key="a.id">
+        <div class="title">{{ a.title }}</div>
+        <div class="progress-bar">
+          <div class="progress" :style="{ width: a.progress + '%' }"></div>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+
+interface Achievement {
+  id: number
+  title: string
+  progress: number
+}
+
+const achievements = ref<Achievement[]>([])
+
+onMounted(() => {
+  const cached = localStorage.getItem('achievements')
+  if (cached) {
+    try {
+      achievements.value = JSON.parse(cached)
+      return
+    } catch (e) {
+      console.error('achievements cache parse error', e)
+    }
+  }
+  achievements.value = [
+    { id: 1, title: 'Первый тест пройден', progress: 100 },
+    { id: 2, title: 'Пройти 5 тестов', progress: 40 },
+    { id: 3, title: 'Набрать 100 баллов', progress: 75 }
+  ]
+  localStorage.setItem('achievements', JSON.stringify(achievements.value))
+})
+</script>
 
 <style scoped>
 .page {
   padding: 1rem;
 }
-.sticker {
-  width: 150px;
-  display: block;
-  margin: 0 auto 1rem;
+.achievements {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.title {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+.progress-bar {
+  height: 6px;
+  background: var(--border-color);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.progress {
+  height: 100%;
+  background: var(--accent-color);
 }
 </style>

--- a/src/views/ResultsView.vue
+++ b/src/views/ResultsView.vue
@@ -1,12 +1,10 @@
 <template>
   <div class="page">
-    <img
-      src="https://media.giphy.com/media/3o6UBpHgaXFDNAuttm/giphy.gif"
-      alt="sticker"
-      class="sticker"
-    />
-    <p>Ваш результат: {{ score }}</p>
-    <button @click="share">Отправить результат</button>
+    <div class="result-card">
+      <h2>Ваш результат</h2>
+      <p class="score">{{ score }}%</p>
+      <button @click="share">Отправить результат</button>
+    </div>
   </div>
 </template>
 
@@ -40,9 +38,18 @@ function share() {
 .page {
   padding: 1rem;
 }
-.sticker {
-  width: 150px;
-  display: block;
-  margin: 0 auto 1rem;
+.result-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.5rem 1rem;
+  background: var(--card-bg);
+  border-radius: 12px;
+}
+.score {
+  font-size: 2rem;
+  font-weight: 600;
+  margin: 0;
 }
 </style>


### PR DESCRIPTION
## Summary
- remove GIFs from pages
- show achievements with progress bars
- redesign results view
- lift up bottom navigation
- tweak global card styles

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684df32006388325b4bc56ed56ad078c