### PR TITLE
Move theme toggle to settings and adjust layout

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,35 +2,14 @@
   <div class="app">
     <router-view />
     <BottomNav />
-    <button
-      class="theme-toggle"
-      @click="toggleTheme"
-      :aria-label="themeLabel"
-    >
-      {{ themeIcon }}
-    </button>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { watch } from 'vue'
 import BottomNav from './components/BottomNav.vue'
-import { close, setHeaderColor } from './telegram'
-
-const theme = ref(localStorage.getItem('theme') || 'light')
-const themeLabel = computed(() =>
-  theme.value === 'dark' ? 'Светлая тема' : 'Тёмная тема'
-)
-const themeIcon = computed(() => (theme.value === 'dark' ? '🌞' : '🌙'))
-
-function toggleTheme() {
-  theme.value = theme.value === 'dark' ? 'light' : 'dark'
-  localStorage.setItem('theme', theme.value)
-}
-
-function closeApp() {
-  close()
-}
+import { setHeaderColor } from './telegram'
+import { theme } from './theme'
 
 watch(
   theme,
@@ -58,19 +37,6 @@ watch(
     var(--tg-safe-area-inset-top, env(safe-area-inset-top))
   );
   overflow-y: auto;
-}
-.theme-toggle {
-  position: fixed;
-  top: calc(
-    var(--tg-content-safe-area-inset-top, var(--tg-safe-area-inset-top, env(safe-area-inset-top))) +
-      3rem
-  );
-  right: 0.5rem;
-  background: var(--card-bg);
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 8px;
-  color: var(--text-color);
 }
 .close-btn {
   position: fixed;

--- a/src/components/BottomNav.vue
+++ b/src/components/BottomNav.vue
@@ -47,7 +47,7 @@ function navigate(path: string) {
   position: fixed;
   bottom: calc(
     var(--tg-content-safe-area-inset-bottom, var(--tg-safe-area-inset-bottom, env(safe-area-inset-bottom))) +
-      1rem
+      1.5rem
   );
   left: 50%;
   transform: translateX(-50%);

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,8 +50,10 @@ async function init() {
         }
       })
       .then(() => {
-        router.push('/tests').then(r => r)
-        createApp(App).use(router).mount('#app')
+        const app = createApp(App)
+        app.use(router)
+        router.replace('/tests')
+        app.mount('#app')
       })
       .catch(e => {
         console.error(e)

--- a/src/router.ts
+++ b/src/router.ts
@@ -3,6 +3,7 @@ import RegisterView from './views/RegisterView.vue'
 import TestsView from './views/TestsView.vue'
 import AchievementsView from './views/AchievementsView.vue'
 import ProfileView from './views/ProfileView.vue'
+import SettingsView from './views/SettingsView.vue'
 import TestView from './views/TestView.vue'
 import ResultsView from './views/ResultsView.vue'
 
@@ -12,6 +13,7 @@ const routes: Array<RouteRecordRaw> = [
   { path: '/tests', component: TestsView },
   { path: '/achievements', component: AchievementsView },
   { path: '/profile', component: ProfileView },
+  { path: '/profile/settings', component: SettingsView },
   { path: '/test/:id', component: TestView },
   { path: '/results/:id', component: ResultsView }
 ]

--- a/src/style.css
+++ b/src/style.css
@@ -42,6 +42,7 @@ body {
   margin: 0.5rem 0;
 }
 .page {
+  padding-top: 0.5rem;
   padding-bottom: calc(
     4.5rem + var(--tg-content-safe-area-inset-bottom, var(--tg-safe-area-inset-bottom, env(safe-area-inset-bottom)))
   );

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,14 @@
+import { ref, computed } from 'vue'
+
+export const theme = ref(localStorage.getItem('theme') || 'light')
+
+export const themeLabel = computed(() =>
+  theme.value === 'dark' ? 'Светлая тема' : 'Тёмная тема'
+)
+
+export const themeIcon = computed(() => (theme.value === 'dark' ? '🌞' : '🌙'))
+
+export function toggleTheme() {
+  theme.value = theme.value === 'dark' ? 'light' : 'dark'
+  localStorage.setItem('theme', theme.value)
+}

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -1,17 +1,30 @@
 <template>
   <div class="page">
-    <p>Имя: {{ name }}</p>
-    <p>Язык: {{ language }}</p>
+    <div class="profile-info">
+      <p>Имя: {{ name }}</p>
+      <p>Язык: {{ language }}</p>
+      <p>Пройдено тестов: {{ testsDone }}</p>
+      <p>Тариф: {{ plan }}</p>
+      <p>Школа: {{ school }}</p>
+    </div>
+    <button @click="editProfile">Редактировать профиль</button>
+    <button @click="openSettings">Настройки</button>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import { apiFetch } from '../api'
 import { getTelegramUser } from '../telegram'
 
+const router = useRouter()
+
 const name = ref('')
 const language = ref('')
+const testsDone = ref(0)
+const plan = ref('Бесплатный')
+const school = ref(localStorage.getItem('school') || 'Школа №1')
 
 onMounted(async () => {
   const user = getTelegramUser()
@@ -39,10 +52,27 @@ onMounted(async () => {
     console.error(e)
   }
 })
+
+function editProfile() {
+  alert('Редактирование профиля пока недоступно')
+}
+
+function openSettings() {
+  router.push('/profile/settings')
+}
 </script>
 
 <style scoped>
 .page {
   padding: 1rem;
+}
+.profile-info {
+  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+button {
+  margin-bottom: 0.5rem;
 }
 </style>

--- a/src/views/RegisterView.vue
+++ b/src/views/RegisterView.vue
@@ -97,6 +97,11 @@ async function proceed() {
     console.log('proceed: registering user')
     await registerUser({ schoolId: schoolId.value, language: language.value })
     console.log('proceed: registration complete')
+    const selected = schools.value.find(s => s.id === schoolId.value)
+    if (selected) {
+      const name = language.value === 'KY' ? selected.nameKy : selected.nameRu
+      localStorage.setItem('school', name)
+    }
     localStorage.setItem('language', language.value)
     localStorage.setItem('registered', '1')
     sendData('registered')

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="page">
+    <button class="theme-toggle" @click="toggleTheme" :aria-label="themeLabel">
+      {{ themeIcon }}
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { themeLabel, themeIcon, toggleTheme } from '../theme'
+</script>
+
+<style scoped>
+.theme-toggle {
+  margin-top: 1rem;
+  background: var(--card-bg);
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  color: var(--text-color);
+}
+</style>


### PR DESCRIPTION
## Summary
- move global theme logic to a new `theme` module
- create Settings page and link from profile
- store selected school on registration
- adjust layout spacing
- fix initial redirect to `#/tests`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684df6c5843c832598d5075563f90af8