### PR TITLE
Update nav icons and add content top padding

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -36,9 +36,12 @@ watch(
         var(--tg-safe-area-inset-bottom, env(safe-area-inset-bottom))
       )
   );
-  padding-top: var(
-    --tg-content-safe-area-inset-top,
-    var(--tg-safe-area-inset-top, env(safe-area-inset-top))
+  padding-top: calc(
+    1rem +
+      var(
+        --tg-content-safe-area-inset-top,
+        var(--tg-safe-area-inset-top, env(safe-area-inset-top))
+      )
   );
   overflow-y: auto;
 }

--- a/src/components/BottomNav.vue
+++ b/src/components/BottomNav.vue
@@ -5,7 +5,7 @@
       :class="{ active: isActive('/tests') }"
       @click="navigate('/tests')"
     >
-      <span class="icon">🏁</span>
+      <FlagIcon class="icon" />
       <span class="label">Тесты</span>
     </div>
     <div
@@ -13,7 +13,7 @@
       :class="{ active: isActive('/achievements') }"
       @click="navigate('/achievements')"
     >
-      <span class="icon">🏆</span>
+      <AwardIcon class="icon" />
       <span class="label">Достижения</span>
     </div>
     <div
@@ -21,7 +21,7 @@
       :class="{ active: isActive('/profile') }"
       @click="navigate('/profile')"
     >
-      <span class="icon">👤</span>
+      <UserIcon class="icon" />
       <span class="label">Профиль</span>
     </div>
   </nav>
@@ -29,6 +29,9 @@
 
 <script setup lang="ts">
 import { useRoute, useRouter } from 'vue-router'
+import FlagIcon from './icons/FlagIcon.vue'
+import AwardIcon from './icons/AwardIcon.vue'
+import UserIcon from './icons/UserIcon.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -99,6 +102,11 @@ function navigate(path: string) {
   background: var(--accent-gradient);
 }
 .icon {
-  font-size: 1.4rem;
+  width: 1.4rem;
+  height: 1.4rem;
+}
+.icon svg {
+  width: 100%;
+  height: 100%;
 }
 </style>

--- a/src/components/icons/AwardIcon.vue
+++ b/src/components/icons/AwardIcon.vue
@@ -1,0 +1,6 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="12" cy="8" r="7" />
+    <polyline points="8.21 13.89 7 23 12 20 17 23 15.79 13.88" />
+  </svg>
+</template>

--- a/src/components/icons/FlagIcon.vue
+++ b/src/components/icons/FlagIcon.vue
@@ -1,0 +1,6 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z"/>
+    <line x1="4" y1="22" x2="4" y2="15" />
+  </svg>
+</template>

--- a/src/components/icons/UserIcon.vue
+++ b/src/components/icons/UserIcon.vue
@@ -1,0 +1,6 @@
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+    <circle cx="12" cy="7" r="4" />
+  </svg>
+</template>


### PR DESCRIPTION
## Summary
- replace emoji icons in BottomNav with monochrome SVGs
- add 1rem top padding to accommodate top safe area

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e56ad5f408325acaa9020d66338b4